### PR TITLE
Add Egg count to Pokemon count

### DIFF
--- a/src/me/corriekay/pokegoutil/windows/PokemonGoMainWindow.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonGoMainWindow.java
@@ -44,7 +44,7 @@ public class PokemonGoMainWindow extends JFrame {
 					+ Utilities.convertTeamColorToName(pp.getPlayerData().getTeamValue()) + " player.");			
 			System.out.println("Pokédex - Types Caught: " + pp.getStats().getUniquePokedexEntries()
 					+ ", Total Pokémon Caught: " + pp.getStats().getPokemonsCaptured() + ", Total Current Pokémon: "
-					+ go.getInventories().getPokebank().getPokemons().size());
+					+ go.getInventories().getPokebank().getPokemons().size() + " (+" + go.getInventories().getHatchery().getEggs().size() + " Eggs)");
 		} catch (RemoteServerException | LoginFailedException e) {
 			System.out.println("Unable to login!");
 			e.printStackTrace();


### PR DESCRIPTION
Egg count added to number of pokemon currently caught to make it more clear why the number isn't exactly the same like in the ingame inventory.

Fixes #142.
