### PR TITLE
Fix Login Error endless Loop

### DIFF
--- a/src/me/corriekay/pokegoutil/controllers/AccountController.java
+++ b/src/me/corriekay/pokegoutil/controllers/AccountController.java
@@ -128,6 +128,7 @@ public final class AccountController {
                     }
                 } catch (Exception e) {
                     alertFailedLogin();
+                    deleteLoginData(LoginType.PTC);
                     continue;
                 }
             } else if (response == JOptionPane.NO_OPTION) {
@@ -172,6 +173,7 @@ public final class AccountController {
                     }
                 } catch (Exception e) {
                     alertFailedLogin();
+                    deleteLoginData(LoginType.GOOGLE);
                     continue;
                 }
 


### PR DESCRIPTION
If you have a wrong token or wrong credentials in `config.json` the login will fail with a message.
That's fine, but it will loop again and try the saved credentials again. Especially for Google Auth this will lead to an endless loop.

Small fix here, just delete saved credentials if the login fails.

There is no issue for that, this is just a fix for something I found while debugging.
